### PR TITLE
Support functions with no call args and with an asterisk.

### DIFF
--- a/lacquer/formatter/formatter.py
+++ b/lacquer/formatter/formatter.py
@@ -107,7 +107,7 @@ class Formatter(AstVisitor):
     def visit_function_call(self, node, unmangle_names):
         ret = ""
         arguments = self._join_expressions(node.arguments, unmangle_names)
-        if not node.arguments and "count" == node.name.suffix.lower():
+        if not node.arguments and "count" == node.name.parts[0].lower():
             arguments = "*"
         if node.distinct:
             arguments = "DISTINCT " + arguments

--- a/lacquer/parsers/parser.py
+++ b/lacquer/parsers/parser.py
@@ -598,9 +598,21 @@ def p_value(p):
 
 
 def p_function_call(p):
-    r"""function_call : qualified_name LPAREN call_list RPAREN"""
+    r"""function_call : qualified_name LPAREN call_args RPAREN"""
     distinct = p[3] is None or p[3] == "DISTINCT"
     p[0] = FunctionCall(p.lineno(1), p.lexpos(1), name=p[1], distinct=distinct, arguments=p[3])
+
+
+def p_call_args(p):
+    r"""call_args : call_list
+                  | empty_call_args"""
+    p[0] = p[1]
+
+
+def p_empty_call_args(p):
+    r"""empty_call_args : ASTERISK
+                        | empty"""
+    p[0] = []
 
 
 def p_case_specification(p):

--- a/test/queries.sql
+++ b/test/queries.sql
@@ -26,6 +26,9 @@ select "!" from dual x;
 select r(x, 1, 2, CURRENT_TIME);
 select cast(a as varchar(2)), b from foo;
 
+select foo() from bar;
+select count(*) from foo;
+
 select y.b from ( select 1 as b from foo as a) y;
 select a.b.c.d from foo;
 select 1 from foo;


### PR DESCRIPTION
`select foo(*) from bar` also parses, but this is consistent with Presto