### PR TITLE
[QualifiedName] Adding __hash__ method

### DIFF
--- a/lacquer/tree/qualified_name.py
+++ b/lacquer/tree/qualified_name.py
@@ -36,3 +36,6 @@ class QualifiedName(object):
         if isinstance(other, self.__class__):
             return self.parts == other.parts
         return False
+
+    def __hash__(self):
+        return hash(tuple(self.parts))


### PR DESCRIPTION
This PR adds the `__hash__` method to the `QualifiedName` type so that, 

```python
>>> a = QualifiedName(('foo', 'bar'))
>>> b = QualifiedName(('foo', 'bar'))
>>> hash(a) == hash(b)
True
```

which will allow a `QualifiedName` object to uniquely represent a dictionary key or item in a set.