### PR TITLE
Fix parser output clash for individual parsers

### DIFF
--- a/lacquer/parsers/parser.py
+++ b/lacquer/parsers/parser.py
@@ -822,5 +822,7 @@ def p_error(p):
         raise err
     raise SyntaxError("Syntax error in input. Check your statement")
 
-parser = yacc.yacc(tabmodule="parser_table")
-expression_parser = yacc.yacc(tabmodule="expression_parser_table", start="single_expression")
+parser = yacc.yacc(tabmodule="parser_table", debugfile="parser.out")
+expression_parser = yacc.yacc(tabmodule="expression_parser_table",
+                              start="single_expression",
+                              debugfile="expression_parser.out")


### PR DESCRIPTION
Don't clash parser.out (built when `yacc.yacc` called)